### PR TITLE
tests: fix get_links and query tests

### DIFF
--- a/das-query-engine/tests/integration/handle/base_test_action.py
+++ b/das-query-engine/tests/integration/handle/base_test_action.py
@@ -29,7 +29,7 @@ class BaseTestHandlerAction(ABC):
     def assert_successful_execution(self, valid_event, expected_output):
         response = handle(valid_event, context={})
         assert response["statusCode"] == 200
-        assert response["body"] == json.dumps(expected_output)
+        assert response["body"] == json.dumps(expected_output), f"Assertion failed:\nResponse Body: {response['body']}\nExpected: {json.dumps(expected_output)}"
 
     def assert_payload_malformed(self, malformed_event):
         response = handle(malformed_event, context={})

--- a/das-query-engine/tests/integration/handle/test_get_links_action.py
+++ b/das-query-engine/tests/integration/handle/test_get_links_action.py
@@ -29,7 +29,6 @@ class TestGetLinksAction(BaseTestHandlerAction):
             {
                 "handle": "ee1c03e6d1f104ccd811cfbba018451a",
                 "type": "Inheritance",
-                "template": ["Inheritance", "Concept", "Concept"],
                 "targets": [
                     "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
                     "80aff30094874e75028033a38ce677bb",

--- a/das-query-engine/tests/integration/handle/test_query_action.py
+++ b/das-query-engine/tests/integration/handle/test_query_action.py
@@ -32,7 +32,6 @@ class TestQueryAction(BaseTestHandlerAction):
             {
                 "handle": "bad7472f41a0e7d601ca294eb4607c3a",
                 "type": "Similarity",
-                "template": ["Similarity", "Concept", "Concept"],
                 "targets": [
                     {
                         "handle": "af12f10f9ae2002a1607ba0b47ba8407",


### PR DESCRIPTION
* Remove template from get_links and query
* Show the expected and response body in the tests