### PR TITLE
[#64] Shutdown containers before run tests

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,6 +6,8 @@ OPENFAAS_CONTAINER="openfaas"
 
 QUERY_ENGINE_SERVICE="query-engine"
 
+docker compose down
+
 if ! docker ps --format '{{.Names}}' | grep -q "$OPENFAAS_CONTAINER"; then
     if [ -z "$REMOTE" ]; then
         docker compose up -d --build --force-recreate


### PR DESCRIPTION
* Run `docker compose down` before running tests

Closes #64 